### PR TITLE
Re-publish the user-agent header to fedmsg.

### DIFF
--- a/mailman3_fedmsg_plugin.py
+++ b/mailman3_fedmsg_plugin.py
@@ -64,6 +64,7 @@ class Archiver(object):
         "references",
         "x-mailman-rule-hits",
         "x-mailman-rule-misses",
+        "user-agent",
     ]
 
     def __init__(self):


### PR DESCRIPTION
This should let us figure out (in the future) what percentage of mailman
traffic originates in the hyperkitty web ui (since it uses a special
user-agent field to indicate that it is sending the message).